### PR TITLE
fix: add event hub authorization rule abbreviation in complete usage

### DIFF
--- a/examples/complete/naming.tf
+++ b/examples/complete/naming.tf
@@ -4,5 +4,5 @@ locals {
     for type in local.naming_types : type => lookup(module.naming, type).name
   }
 
-  naming_types = ["eventhub", "eventhub_consumer_group"]
+  naming_types = ["eventhub", "eventhub_consumer_group", "eventhub_namespace_authorization_rule"]
 }


### PR DESCRIPTION
## Description

The authorization rule rule naming abbreviation is added in the complete usage

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #17
