### PR TITLE
feat: support authorization rules for individual eventhubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_eventhub_namespace_authorization_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace_auth) | resource |
 | [azurerm_eventhub_namespace_schema_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace_schema_group) | resource |
 | [azurerm_eventhub_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_cluster) | resource |
+| [eventhub_authorization_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_authorization_rule) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_eventhub_namespace_authorization_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace_auth) | resource |
 | [azurerm_eventhub_namespace_schema_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace_schema_group) | resource |
 | [azurerm_eventhub_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_cluster) | resource |
-| [eventhub_authorization_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_authorization_rule) | resource |
+| [azurerm_eventhub_authorization_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_authorization_rule) | resource |
 
 ## Inputs
 

--- a/examples/authorization-rules/README.md
+++ b/examples/authorization-rules/README.md
@@ -9,6 +9,16 @@ namespace = object({
   name           = string
   location       = string
   resource_group = string
+  eventhubs = optional(map(object({
+    partition_count   = number
+    message_retention = number
+    authorization_rules = optional(map(object({
+      name   = optional(string)
+      listen = optional(bool, false)
+      send   = optional(bool, false)
+      manage = optional(bool, false)
+    })))
+  })))
 
   authorization_rules = optional(map(object({
     name   = optional(string)

--- a/examples/authorization-rules/main.tf
+++ b/examples/authorization-rules/main.tf
@@ -27,6 +27,22 @@ module "eventhub" {
     name           = module.naming.eventhub_namespace.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
+    eventhubs = {
+      datahub = {
+        partition_count   = 2,
+        message_retention = 1,
+        authorization_rules = {
+          users = {
+            listen = true
+          }
+          admins = {
+            listen = true
+            send   = true
+            manage = true
+          }
+        }
+      }
+    }
 
     authorization_rules = {
       users = {

--- a/examples/authorization-rules/naming.tf
+++ b/examples/authorization-rules/naming.tf
@@ -4,5 +4,5 @@ locals {
     for type in local.naming_types : type => lookup(module.naming, type).name
   }
 
-  naming_types = ["eventhub_namespace_authorization_rule"]
+  naming_types = ["eventhub", "eventhub_namespace_authorization_rule", "eventhub_authorization_rule"]
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -16,6 +16,12 @@ namespace = object({
     consumer_groups = optional(map(object({
       user_metadata = string
     })))
+    authorization_rules = optional(map(object({
+      name   = optional(string)
+      listen = optional(bool, false)
+      send   = optional(bool, false)
+      manage = optional(bool, false)
+    })))
   })))
 
   schema_groups = optional(map(object({

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,6 +40,16 @@ module "eventhub" {
             user_metadata = "system_metrics"
           }
         }
+        authorization_rules = {
+          users = {
+            listen = true
+          }
+          admins = {
+            listen = true
+            send   = true
+            manage = true
+          }
+        }
       }
     }
     schema_groups = {

--- a/examples/complete/naming.tf
+++ b/examples/complete/naming.tf
@@ -4,5 +4,5 @@ locals {
     for type in local.naming_types : type => lookup(module.naming, type).name
   }
 
-  naming_types = ["eventhub", "eventhub_consumer_group", "eventhub_namespace_authorization_rule"]
+  naming_types = ["eventhub", "eventhub_consumer_group", "eventhub_namespace_authorization_rule", "eventhub_authorization_rule"]
 }

--- a/examples/eventhubs/README.md
+++ b/examples/eventhubs/README.md
@@ -13,6 +13,12 @@ namespace = object({
   eventhubs = optional(map(object({
     partition_count   = number
     message_retention = number
+    authorization_rules = optional(map(object({
+      name   = optional(string)
+      listen = optional(bool, false)
+      send   = optional(bool, false)
+      manage = optional(bool, false)
+    })))
   })))
 })
 ```

--- a/examples/eventhubs/main.tf
+++ b/examples/eventhubs/main.tf
@@ -32,10 +32,30 @@ module "eventhub" {
       alerts = {
         partition_count   = 2
         message_retention = 1
+        authorization_rules = {
+          users = {
+            listen = true
+          }
+          admins = {
+            listen = true
+            send   = true
+            manage = true
+          }
+        }
       }
       metrics = {
         partition_count   = 4
         message_retention = 2
+        authorization_rules = {
+          users = {
+            listen = true
+          }
+          admins = {
+            listen = true
+            send   = true
+            manage = true
+          }
+        }
       }
     }
   }

--- a/examples/eventhubs/naming.tf
+++ b/examples/eventhubs/naming.tf
@@ -4,5 +4,5 @@ locals {
     for type in local.naming_types : type => lookup(module.naming, type).name
   }
 
-  naming_types = ["eventhub"]
+  naming_types = ["eventhub", "eventhub_authorization_rule"]
 }


### PR DESCRIPTION
## Description

The authorization rule for Event Hub namespaces is available, but authorization rules for individual Event Hubs are not supported by the module.


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules




## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (i.e. adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #35
