### PR TITLE
feat: added zone_redundant  property for event hub namespace

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -9,6 +9,7 @@ namespace = object({
   name           = string
   location       = string
   resource_group = string
+  zone_redundant = optional(string)
 
   eventhubs = optional(map(object({
     partition_count   = number

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,7 +27,7 @@ module "eventhub" {
     name           = module.naming.eventhub_namespace.name
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-
+    zone_redundant = true
     eventhubs = {
       datahub = {
         partition_count   = 2,

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ resource "azurerm_eventhub_namespace" "ns" {
   network_rulesets              = try(var.namespace.network_rulesets, [])
   local_authentication_enabled  = try(var.namespace.local_authentication_enabled, false)
   public_network_access_enabled = try(var.namespace.public_network_access_enabled, true)
+  zone_redundant                = try(var.namespace.zone_redundant, false)
   tags                          = try(var.namespace.tags, var.tags, null)
 
   lifecycle {


### PR DESCRIPTION
## Description

The latest module update has eliminated the **zone_redundant** property, leading to the existing code that activates **zone_redundancy** defaulting to false. Due to that, this triggers the deletion of the current resource and the establishment of a new one. The property is optional and should be incorporated into the module.


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_eventhub_namespace` - support for the `zone_redundant` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #39 
